### PR TITLE
Update incident_lights.yaml

### DIFF
--- a/blueprints/automation/fireservicerota/incident_lights.yaml
+++ b/blueprints/automation/fireservicerota/incident_lights.yaml
@@ -9,6 +9,7 @@ blueprint:
       description: The standard incident sensor added by FireServiceRota. Please select the correct one if you changed the entity name of the sensor.
       selector:
         entity:
+          integration: fireservicerota
           domain: sensor
     target_light:
       name: Lights


### PR DESCRIPTION
Make sure only the fireservicerota sensor can be selected for the automation, makes it much easier to find the right entity for a user